### PR TITLE
#25 - Adding a :target highlight for FAQs. 

### DIFF
--- a/sites/all/themes/pfo/css/style.css
+++ b/sites/all/themes/pfo/css/style.css
@@ -1281,6 +1281,10 @@ footer h2 {
   padding-top: 2em;
 }
 
+.view-id-faq_view .views-row {
+  margin: .8em 0;
+}
+
 #magic-search {
   display: block;
   width: 80%;
@@ -1299,8 +1303,68 @@ footer h2 {
   box-shadow: 0 0 6px 1px #c54b2c;
 }
 
-.view-id-faq_view .views-row {
-  margin: .8em 0;
+.view-id-faq_view :target {
+  -webkit-animation: highlight 3s ease-in-out;
+  -moz-animation: highlight 3s ease-in-out;
+  -ms-animation: highlight 3s ease-in-out;
+  -o-animation: highlight 3s ease-in-out;
+  animation: highlight 3s ease-in-out;
+}
+
+@-webkit-keyframes highlight {
+  0% {
+    background: #ffb;
+  }
+
+  50% {
+    background: #ffb;
+  }
+
+  100% {
+    background: transparent;
+  }
+}
+
+@-moz-keyframes highlight {
+  0% {
+    background: #ffb;
+  }
+
+  50% {
+    background: #ffb;
+  }
+
+  100% {
+    background: transparent;
+  }
+}
+
+@-ms-keyframes highlight {
+  0% {
+    background: #ffb;
+  }
+
+  50% {
+    background: #ffb;
+  }
+
+  100% {
+    background: transparent;
+  }
+}
+
+@-o-keyframes highlight {
+  0% {
+    background: #ffb;
+  }
+
+  50% {
+    background: #ffb;
+  }
+
+  100% {
+    background: transparent;
+  }
 }
 
 /**

--- a/sites/all/themes/pfo/sass/style.scss
+++ b/sites/all/themes/pfo/sass/style.scss
@@ -359,6 +359,12 @@ footer h2 {
   padding-top: 2em;
 }
 
+.view-id-faq_view .views-row {
+  margin: .8em 0;
+}
+
+// FAQs search
+
 #magic-search {
   display: block;
   width: 80%;
@@ -373,9 +379,38 @@ footer h2 {
   box-shadow: 0 0 6px 1px $burnt-red;
 }
 
-.view-id-faq_view .views-row {
-  margin: .8em 0;
+// These styles cause the title to be highlighted
+// when you deep-link to a particular FAQ
+.view-id-faq_view :target {
+  -webkit-animation: highlight 3s ease-in-out;
+     -moz-animation: highlight 3s ease-in-out;
+      -ms-animation: highlight 3s ease-in-out;
+       -o-animation: highlight 3s ease-in-out;
+          animation: highlight 3s ease-in-out;
 }
+
+@-webkit-keyframes highlight {
+  0% { background: #ffb; }
+  50% { background: #ffb; }
+  100% { background: transparent; }
+}
+@-moz-keyframes highlight {
+  0% { background: #ffb; }
+  50% { background: #ffb; }
+  100% { background: transparent; }
+}
+@-ms-keyframes highlight {
+  0% { background: #ffb; }
+  50% { background: #ffb; }
+  100% { background: transparent; }
+}
+@-o-keyframes highlight {
+  0% { background: #ffb; }
+  50% { background: #ffb; }
+  100% { background: transparent; }
+}
+
+
 
 
 /**

--- a/sites/all/themes/pfo/tpl/page--front.tpl.php
+++ b/sites/all/themes/pfo/tpl/page--front.tpl.php
@@ -24,7 +24,7 @@
           <div class="download">
             <h2>Download and install</h2>
             <?php print $download; ?>
-            <p class="pf7">Looking for Pressflow 7?<br> Check the progress on <a href="https://github.com/pressflow/7">Github</a></p>
+            <p class="pf7"><a href="/faq#faq-title-id-8">Looking for Pressflow 7?</a><br> Check the progress on <a href="https://github.com/pressflow/7">Github</a></p>
           </div><!-- .download -->
         </div><!-- .container -->
         </div><!-- .stripe -->


### PR DESCRIPTION
It only activates when you anchor to a particular FAQ. Other page IDs are unaffected.
